### PR TITLE
Send logs to Stdout

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,5 +15,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.61
           skip-cache: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,9 +8,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          version: v1.54
-          skip-go-installation: true
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60
+          skip-cache: true

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -13,8 +13,8 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:
-          args: -exclude=G306 ./...
+          args: -exclude=G306 -exclude=G115 ./...

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The entry_point can be tuned using any of the following env vars:
 ```AUTOSTART```: If False will set all the processed from supervisor to autostart false, if true basically won't change
 anything because is assumed that all processes are autostart true by default
 
+```ORCHESTSH_STDOUT```: Will force all the instance logs to the standard output, this is usefully when deploying the
+container in kubernetes or docker swarm, all the logs can be read by any collector that can read the container logs.
+
 Configuring Odoo instance
 --
 

--- a/utils/bash.go
+++ b/utils/bash.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"math"
 	"os"
 	"os/exec"
 	"os/user"
@@ -24,11 +25,18 @@ func GetUserUIDs(username string) (uint32, uint32, error) {
 	if err != nil {
 		return 0, 0, err
 	}
+	if uid < 0 || uid > math.MaxUint32 {
+		uid = 0
+	}
 
 	gid, err := strconv.Atoi(u.Gid)
 	if err != nil {
 		return 0, 0, err
 	}
+	if gid < 0 || uid > math.MaxUint32 {
+		gid = 0
+	}
+
 	return uint32(uid), uint32(gid), nil
 }
 

--- a/utils/odoo.go
+++ b/utils/odoo.go
@@ -150,7 +150,7 @@ func SetupWorker(config *ini.File, containerType string) {
 	}
 }
 
-// UpdateFromVars will update the odoo configuration from env vars wich should start with ODOORC_ prefix, if the exists
+// UpdateFromVars will update the odoo configuration from env vars which should start with ODOORC_ prefix, if the exists
 // the value  will be updated else the parameter will be added to the 'options' section only when appendNew == true,
 // which is the default for Odoo.
 // If you wish to add it to another section add the desired section to '/external_files/openerp_serverrc' or add
@@ -167,7 +167,7 @@ func UpdateFromVars(config *ini.File, odooVars map[string]string, appendNew bool
 				break
 			}
 		}
-		// The key does not exist and we want to force append, so we add it into the options section
+		// The key does not exist, and we want to force append, so we add it into the options section
 		if !updated && appendNew {
 			config.Section("options").Key(k).SetValue(v)
 		}
@@ -175,7 +175,7 @@ func UpdateFromVars(config *ini.File, odooVars map[string]string, appendNew bool
 }
 
 // SetDefaults takes care of important defaults:
-// - Won't allow admin as default super user password, a random string is generated
+// - Won't allow admin as default superuser password, a random string is generated
 // - Won't allow to change the default ports because inside the container is not needed and will mess with the external
 // - Disable logrotate since supervisor will handle that
 func SetDefaults(config *ini.File) {

--- a/utils/supervisor.go
+++ b/utils/supervisor.go
@@ -46,7 +46,7 @@ func UpdateAutostart(autostart bool, confPath string) error {
 	return nil
 }
 
-// setAutostart will enable the autostart in a particular file, but won't touch the default section neither supervisor one
+// setAutostart will enable autostart in a particular file, but won't touch the default section neither supervisor one
 // only in the services section
 func setAutostart(content []byte, w io.Writer) error {
 	cfg, err := ini.Load(content)

--- a/utils/supervisor.go
+++ b/utils/supervisor.go
@@ -11,13 +11,9 @@ import (
 	"gopkg.in/ini.v1"
 )
 
-// UpdateAutostart will look for all the services configuration in the supervisor conf.d directory and
-// update autostart. If autostart is true nothing will change, if false all values will be set to false
-func UpdateAutostart(autostart bool, confPath string) error {
-	// if autostart is true we do nothing because should use the default configuration
-	if autostart {
-		return nil
-	}
+// UpdateSupervisor will look for all the services configuration in the supervisor conf.d directory and
+// update the configuration accordingly applying the setter function.
+func UpdateSupervisor(confPath string, setter func(content []byte, w io.Writer) error) error {
 
 	files, err := os.ReadDir(confPath)
 	if err != nil {
@@ -38,7 +34,7 @@ func UpdateAutostart(autostart bool, confPath string) error {
 			return err
 		}
 		defer w.Close()
-		err = setAutostart(content, w)
+		err = setter(content, w)
 		if err != nil {
 			return err
 		}
@@ -46,9 +42,9 @@ func UpdateAutostart(autostart bool, confPath string) error {
 	return nil
 }
 
-// setAutostart will enable autostart in a particular file, but won't touch the default section neither supervisor one
+// SetAutostart will enable autostart in a particular file, but won't touch the default section neither supervisor one
 // only in the services section
-func setAutostart(content []byte, w io.Writer) error {
+func SetAutostart(content []byte, w io.Writer) error {
 	cfg, err := ini.Load(content)
 	if err != nil {
 		return err
@@ -58,6 +54,27 @@ func setAutostart(content []byte, w io.Writer) error {
 		if section.Name() != "supervisord" && section.Name() != "DEFAULT" {
 			section.Key("autostart").SetValue("false")
 		}
+	}
+	if _, err := cfg.WriteTo(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetStout will enable stdout_logfile and stderr_logfile in a particular configuration file so all the output will be
+// sent to the standard output instead of a file as usually is set
+func SetStout(content []byte, w io.Writer) error {
+	cfg, err := ini.Load(content)
+	if err != nil {
+		return err
+	}
+	for _, section := range cfg.Sections() {
+		if section.Name() == "supervisord" || section.Name() == "DEFAULT" {
+			continue
+		}
+		section.Key("stdout_logfile").SetValue("/dev/fd/1")
+		section.Key("stderr_logfile").SetValue("/dev/fd/1")
+		section.Key("stdout_logfile_maxbytes").SetValue("0")
 	}
 	if _, err := cfg.WriteTo(w); err != nil {
 		return err


### PR DESCRIPTION
With this change, we add a new environment variable that allows us to send the Odoo logs directly to the stdout.

Also, some minor updates in documentation.