### PR TITLE
[FIX] entrypoint: fix log error when use the entrypoint in a k8s pod

### DIFF
--- a/utils/supervisor.go
+++ b/utils/supervisor.go
@@ -75,6 +75,7 @@ func SetStout(content []byte, w io.Writer) error {
 		section.Key("stdout_logfile").SetValue("/dev/fd/1")
 		section.Key("stderr_logfile").SetValue("/dev/fd/1")
 		section.Key("stdout_logfile_maxbytes").SetValue("0")
+		section.Key("stderr_logfile_maxbytes").SetValue("0")
 	}
 	if _, err := cfg.WriteTo(w); err != nil {
 		return err


### PR DESCRIPTION
## description

Before this changes, when trying to show the logs in the output of docker, it shows the Odoo logs and another error log (this logs should not trigger):

- ![image](https://github.com/user-attachments/assets/0d323d1a-3c28-4966-b6e9-1b11df53b923)


and now with those changes, it shows the Odoo logs well:

- ![image](https://github.com/user-attachments/assets/33b3713b-3dd1-471d-b6cc-b71a376df0e8)



More information about the fix: https://github.com/Supervisor/supervisor/issues/935