### PR TITLE
[FIX] Autostart configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ The entry_point can be tuned using any of the following env vars:
 
 ```DEBUG_ENTRYPOINT```: Will log debug output and be more verbose
 
-```AUTOSTART```: If False will set all the processed from supervisor to autostart false, if true basically won't change
-anything because is assumed that all processes are autostart true by default
+```AUTOSTART```: If False will set all the processed from supervisor to autostart false, if true will **only**
+set the `odoo` process to true, will leave the others as they are set. In case the var is not set, nothing will change.
 
 ```ORCHESTSH_STDOUT```: Will force all the instance logs to the standard output, this is usefully when deploying the
 container in kubernetes or docker swarm, all the logs can be read by any collector that can read the container logs.

--- a/utils/odoo.go
+++ b/utils/odoo.go
@@ -250,10 +250,14 @@ func Odoo() error {
 		}
 		log.Debugf("Autostart: %v", autostart)
 
-		if autostart {
+		if !autostart {
 			if err := UpdateSupervisor("/etc/supervisor/conf.d", SetAutostart); err != nil {
 				return err
 			}
+		}
+
+		if err := UpdateSupervisor("/etc/supervisor/conf.d", AutoStartOdoo(autostart)); err != nil {
+			return err
 		}
 	}
 

--- a/utils/supervisor.go
+++ b/utils/supervisor.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -70,6 +71,28 @@ func SetAutostart(content []byte, w io.Writer) error {
 		return err
 	}
 	return nil
+}
+
+// AutoStartOdoo will enable autostart for Odoo only. This is an important distinction
+// from SetAutostart that will do in all sections and files. Returns a function that can be passed to
+// UpdateSupervisor.
+func AutoStartOdoo(value bool) func([]byte, io.Writer) error {
+	return func(content []byte, w io.Writer) error {
+		cfg, err := ini.Load(content)
+		if err != nil {
+			return err
+		}
+		sections := cfg.Sections()
+		for _, section := range sections {
+			if section.Name() == "odoo" {
+				section.Key("autostart").SetValue(strconv.FormatBool(value))
+			}
+		}
+		if _, err := cfg.WriteTo(w); err != nil {
+			return err
+		}
+		return nil
+	}
 }
 
 // SetStout will enable stdout_logfile and stderr_logfile in a particular configuration file so all the output will be


### PR DESCRIPTION
The autostart had a bug where it was setting the variable to false always, regardless of what value it had (as long as it had a value).

Added a second setter to force the autostart value of the Odoo instance in particular. This solves the issue where the variable wasn't updated when we executed more complicated workflows (mainly initialization) where we restarted the container with different values for AUTOSTART.