### PR TITLE
[FIX] utils: Normalize Odoo versions for semver validation

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,14 +11,14 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: '1.26'
       - name: Download dependencies
         run: go mod download
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1
+          version: v2.12.2
           skip-cache: true

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -13,7 +13,7 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,17 +14,17 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.22
+          go-version: '1.26'
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: ['1.26']
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -12,10 +12,10 @@ jobs:
       run: |
            echo "CGO_ENABLED=0" >> $GITHUB_ENV
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Test
       run: go test ./...

--- a/utils/odoo.go
+++ b/utils/odoo.go
@@ -15,6 +15,24 @@ import (
 
 type envConverter func([]string) map[string]string
 
+// NormalizeVersionForSemver normalizes Odoo version strings (e.g., saas-19.2, master)
+// so they can be safely parsed by golang.org/x/mod/semver.
+func NormalizeVersionForSemver(version string) string {
+	v := strings.TrimSpace(version)
+	if v == "master" {
+		return "v999.0"
+	}
+	v = strings.ReplaceAll(v, "saas-", "")
+	if !strings.HasPrefix(v, "v") {
+		v = "v" + v
+	}
+	// Add .0 if it's just a major version
+	if strings.Count(v, ".") == 0 {
+		v = v + ".0"
+	}
+	return v
+}
+
 // GetOdooUser is for future use, so far we do not plan to use other user that odoo to execute the instance
 func GetOdooUser() string {
 	user := os.Getenv("ODOO_USER")
@@ -143,7 +161,8 @@ func SetupWorker(config *ini.File, containerType, version string) {
 		config.Section("options").Key("workers").SetValue("-1")
 		config.Section("options").Key("xmlrpcs").SetValue("False")
 		config.Section("options").Key("xmlrpc").SetValue("False")
-		if semver.Compare("v"+version, "v16.0") == -1 {
+		normalizedVersion := NormalizeVersionForSemver(version)
+		if semver.Compare(normalizedVersion, "v16.0") == -1 {
 			config.Section("options").Key("workers").SetValue("0")
 		}
 
@@ -189,12 +208,14 @@ func SetDefaults(config *ini.File, version string) {
 	config.Section("options").Key("gevent_port").SetValue("8072")
 	config.Section("options").Key("http_port").SetValue("8069")
 
-	if semver.Compare("v"+version, "v16.0") == -1 {
+	normalizedVersion := NormalizeVersionForSemver(version)
+
+	if semver.Compare(normalizedVersion, "v16.0") == -1 {
 		config.Section("options").Key("longpolling_port").SetValue("8072")
 		config.Section("options").Key("xmlrpc_port").SetValue("8069")
 	}
 
-	if semver.Compare("v"+version, "v13.0") == -1 {
+	if semver.Compare(normalizedVersion, "v13.0") == -1 {
 		config.Section("options").Key("logrotate").SetValue("False")
 	} else {
 		config.Section("options").DeleteKey("logrotate")


### PR DESCRIPTION
The semantic versioning comparisons were failing when processing non-standard version formats such as 'saas-19.2' and 'master'. Because they didn't follow the strictly numerical format, they were evaluated as older/invalid versions.

This caused the entrypoint to incorrectly inject deprecated parameters like 'longpolling_port', 'xmlrpc_port', and 'logrotate' into the .odoorc when booting Odoo 19/20 instances.

This change:
- Introduces NormalizeVersionForSemver to clean the version strings
- Handles 'master' as v999.0 to always consider it the latest
- Handles 'saas-X' prefixes by stripping them
- Applies the normalizer in SetupWorker and SetDefaults logic